### PR TITLE
lte-check-hotfix2

### DIFF
--- a/qa/check_enabled_services.py
+++ b/qa/check_enabled_services.py
@@ -28,8 +28,8 @@ def test_LTE():
     subprocess.run(["rm", "-f", "/data/recording/lte-status.log"])
     time.sleep(1)
     subprocess.run(["systemctl", "start", "lte"])
-    print("Waiting 10 seconds for initial LTE log write")
-    time.sleep(10)
+    print("Waiting 30 seconds for initial LTE log write")
+    time.sleep(35)
     subprocess.run(["sync"])
     subprocess.run(["cp", "/data/recording/lte-status.log", "/tmp/lte_capture.txt"])
 
@@ -76,8 +76,7 @@ def check_enabled_services():
 
 def lte_file_check():
     """Checks for OK responses from initial AT commands for modem config"""
-    command_set_check = ["'AT'",
-                         "'AT#USBCFG?'",
+    command_set_check = ["'AT#USBCFG?'",
                          "'AT+GMM'"]
     command_result_map = {}
     contents = []


### PR DESCRIPTION
check_enabled_services fix - Increase delay between LTE bringup and execution to 35 seconds.

More:

Some units fail the initial AT command and force an LTE restart, which may take up to 30 seconds. This ignores those initial ATs which may fail before the restart and is more forgiving for the init script