### PR TITLE
Cniessl hb/gnss qa datalogger vers

### DIFF
--- a/qa_gnss/gnss_auto_qa.py
+++ b/qa_gnss/gnss_auto_qa.py
@@ -126,18 +126,16 @@ class GnssQa():
                     elif self.state == 3:
                         self.check_ttff = self._check_ttff()
                         # Niessl 2025-02-23: In the original code, it looks like if the version 
-                        # is later than 5.1.16, then we skip FSYNC. If this is intended, then
-                        # uncomment the original code. 
-                        self.state += 1
-                        # Original per comment above
-                        '''
+                        # is later than 5.1.16, then we skip FSYNC. When trying the FSYNC with
+                        # later versions this stopped/froze the test. If this is correct, then
+                        # remove this comment.
                         if less_than(self.firmware_version, "5.1.16"):
                             print(f"Version is {self.firmware_version}, doing FSYNC")
                             self.state += 1
                         else:
                             print(f"Version is {self.firmware_version}, skipping FSYNC")
                             self.state += 2
-                        '''
+                        
             elif self.state == 1:
                 if self.first_fix_count is None:
                     self.first_fix_count = self.count
@@ -191,7 +189,8 @@ class GnssQa():
                 subprocess.run(["systemctl", "stop", "hivemapper-data-logger"])
                 print("hivemapper-data-logger presumably stopped")
                 time.sleep(10)
-                subprocess.run(["chmod", "+x", "/data/qa_gnss/datalogger"])
+                if less_than(self.firmware_version, "5.2.7"):
+                    subprocess.run(["chmod", "+x", "/data/qa_gnss/datalogger"])
                 self.check_fsync_connection = self._check_fsync_connection()
                 subprocess.run(["systemctl", "enable", "hivemapper-data-logger"])
                 subprocess.run(["systemctl", "start", "hivemapper-data-logger"])

--- a/qa_gnss/gnss_auto_qa.py
+++ b/qa_gnss/gnss_auto_qa.py
@@ -125,11 +125,19 @@ class GnssQa():
                         self.state += 1
                     elif self.state == 3:
                         self.check_ttff = self._check_ttff()
+                        # Niessl 2025-02-23: In the original code, it looks like if the version 
+                        # is later than 5.1.16, then we skip FSYNC. If this is intended, then
+                        # uncomment the original code. 
+                        self.state += 1
+                        # Original per comment above
+                        '''
                         if less_than(self.firmware_version, "5.1.16"):
+                            print(f"Version is {self.firmware_version}, doing FSYNC")
                             self.state += 1
                         else:
+                            print(f"Version is {self.firmware_version}, skipping FSYNC")
                             self.state += 2
-
+                        '''
             elif self.state == 1:
                 if self.first_fix_count is None:
                     self.first_fix_count = self.count

--- a/qa_gnss/gnss_auto_qa.py
+++ b/qa_gnss/gnss_auto_qa.py
@@ -125,10 +125,6 @@ class GnssQa():
                         self.state += 1
                     elif self.state == 3:
                         self.check_ttff = self._check_ttff()
-                        # Niessl 2025-02-23: In the original code, it looks like if the version 
-                        # is later than 5.1.16, then we skip FSYNC. When trying the FSYNC with
-                        # later versions this stopped/froze the test. If this is correct, then
-                        # remove this comment.
                         if less_than(self.firmware_version, "5.1.16"):
                             print(f"Version is {self.firmware_version}, doing FSYNC")
                             self.state += 1

--- a/qa_gnss/gnss_auto_qa.py
+++ b/qa_gnss/gnss_auto_qa.py
@@ -364,7 +364,14 @@ class GnssQa():
         fsync_waits = []
         fsync_wait_count = 0
 
-        command = ["/data/qa_gnss/datalogger", "log",
+        # Niessl 2025-02-23: Version 5.2.7 and later logs FSYNC correctly.
+        # TODO: Change this earlier if any previous versions also support it.
+        datalogger_path = "/data/qa_gnss/datalogger"
+        if geq(self.firmware_version, "5.2.7"):
+            datalogger_path = "/opt/dashcam/bin/datalogger"
+        print(f"Using {datalogger_path}")
+
+        command = [datalogger_path, "log",
                    "--gnss-mga-offline-file-path=/data/mgaoffline.ubx",
                    "--imu-json-destination-folder=/data/recording/imu",
                    "--gnss-json-destination-folder=/data/recording/gps",

--- a/qa_gnss/run_gnss_qa_wifi.sh
+++ b/qa_gnss/run_gnss_qa_wifi.sh
@@ -20,7 +20,7 @@ JSON_FILE="/usr/share/datalogs/current_cam_ver.json"
 VERSION=$(grep '"odc-version"' "$JSON_FILE" | sed -E 's/.*"odc-version"[[:space:]]*:[[:space:]]*"([0-9.]+)".*/\1/')
 
 
-ssh -r -o StrictHostKeyChecking=no root@192.168.0.10 "mkdir -p /data/qa_gnss"
+ssh -t -o StrictHostKeyChecking=no root@192.168.0.10 "mkdir -p /data/qa_gnss"
 scp -r -o StrictHostKeyChecking=no $dir_path/qa_gnss/*.py root@192.168.0.10:/data/qa_gnss
 scp -r -o StrictHostKeyChecking=no $dir_path/qa_gnss/*.sh root@192.168.0.10:/data/qa_gnss
 

--- a/qa_gnss/run_gnss_qa_wifi.sh
+++ b/qa_gnss/run_gnss_qa_wifi.sh
@@ -13,16 +13,28 @@ read name
 echo "Enter S/N of Bee device:"
 read sn
 
-scp -r -o StrictHostKeyChecking=no $dir_path/qa_gnss/ root@192.168.0.10:/data
+# First copy over the JSON file because it's not LOCAL!
+# Need this to figure out what to copy over
+scp -r -o StrictHostKeyChecking=no root@192.168.0.10:/etc/build_info.json /usr/share/datalogs/current_cam_ver.json
+JSON_FILE="/usr/share/datalogs/current_cam_ver.json"
+VERSION=$(grep '"odc-version"' "$JSON_FILE" | sed -E 's/.*"odc-version"[[:space:]]*:[[:space:]]*"([0-9.]+)".*/\1/')
+
+
+ssh -r -o StrictHostKeyChecking=no root@192.168.0.10 "mkdir -p /data/qa_gnss"
+scp -r -o StrictHostKeyChecking=no $dir_path/qa_gnss/*.py root@192.168.0.10:/data/qa_gnss
+scp -r -o StrictHostKeyChecking=no $dir_path/qa_gnss/*.sh root@192.168.0.10:/data/qa_gnss
+
+# Upload datalogger if running on older version
+if [ "$VERSION" == "$PREVIOUS_VERSION" ]; then
+  scp -o StrictHostKeyChecking=no $dir_path/qa_gnss/datalogger root@192.168.0.10:/data/qa_gnss
+fi
+
 ssh -t -o StrictHostKeyChecking=no root@192.168.0.10 "python3 /data/qa_gnss/gnss_auto_qa.py --name \"$name\" --sn \"$sn\""
 ssh -t -o StrictHostKeyChecking=no root@192.168.0.10 "cat /data/qa_gnss_results_\"$name\"_\"$sn\".log"
 
-# First copy over the JSON file because it's not LOCAL!
-scp -r -o StrictHostKeyChecking=no root@192.168.0.10:/etc/build_info.json /usr/share/datalogs/current_cam_ver.json
 
-# Copy over files based on firmware version
-JSON_FILE="/usr/share/datalogs/current_cam_ver.json"
-VERSION=$(grep '"odc-version"' "$JSON_FILE" | sed -E 's/.*"odc-version"[[:space:]]*:[[:space:]]*"([0-9.]+)".*/\1/')
+
+# Download results based on firmware version
 if [ "$VERSION" == "$PREVIOUS_VERSION" ]; then
   echo "Running on previous version"
   scp -r -o StrictHostKeyChecking=no root@192.168.0.10:/data/redis_handler/ /usr/share/datalogs/redis_handler_"$name"_"$sn"_"$fmt_date"


### PR DESCRIPTION
# GNSS_QA Version checking for datalogger behavior. 

## Overview

- [ ] Quick fix (Solves an immediate observed deficiency, error, or vulnerability)
- [ ] Redesign (Reorganizes or removes code to be more reusable, or reuse other libraries)
- [x] Implementation (Implements a new feature, library or extends existing ones)
- [ ] Other (Documentation, Testing, Formatting, Example Code, Code uploaded for review, etc)

## What? - Description of changes

Moves version checking of the Hive Software in the GNSS_QA scripts to before file upload.
For 5.2.7 and later, local datalogger executable is not uploaded.

## Why?

The datalogger that is installed as part of HiveOS 5.2.7 and later has the FSYNC features built-in.
Not uploading it saves time on testing cameras that have the latest OS image installed beforehand.

## Verification/Testing

Tested on a red-tagged unit for LTE issues, but with functional IMU and GNSS components.

## How? (Optional)

Leverages the existing /etc/build_info.json file for versioning information.  

## Impact/Communications (Optional)

--

## Additional Information (Optional)

FSYNC checks seemed to be skipped with version 5.1.16, trying it with 5.2.7 caused datalogger to become non-responsive, and I wasn't sure if that was anticipated or expected behavior. I've commented about this in that section.

<!-- (Credit: <https://github.com/pieterherman-dev/PR-Template-Guide/tree/main> - modified internally) -->