### PR TITLE
add enabling beekeeper-plugin

### DIFF
--- a/qa/check_enabled_services.py
+++ b/qa/check_enabled_services.py
@@ -207,7 +207,7 @@ def main():
         build_info = json.load(file)
     firmware_version = build_info["odc-version"]
 
-    if geq(firmware_version, "5.4.7"):
+    if geq(firmware_version, "5.2.0"):
         db_path = get_json_config("ODC_API_DB_PATH")
         plugin_name = "beekeeper-plugin"
         state = "enabled"


### PR DESCRIPTION
Enables beekeeper-plugin within the plugins table of odc-api database.

Tests I verified:
- it enables plugin under nominal conditions
- the plugin enabling function doesn't run if firmware below 5.4.7
- it fails if odc-api.db is not present on device
- it fails if db write has a disk I/O error
- it fails if the odc-api database path is not available from the config.json