### PR TITLE
check_enabled_services.py - Support changes to db-path based on version

### DIFF
--- a/qa/check_enabled_services.py
+++ b/qa/check_enabled_services.py
@@ -166,6 +166,8 @@ def get_json_config(key, firmware_version):
     ----------
     key : str
         The key to get from the JSON configuration file
+    firmware_version: str
+        The firmware version, which may affect the config file path
 
     Returns
     -------

--- a/qa/check_enabled_services.py
+++ b/qa/check_enabled_services.py
@@ -156,7 +156,7 @@ def less_than(ver1, ver2):
     """ Returns true if ver1 < ver2"""
     return not geq(ver1, ver2)
 
-def get_json_config(key):
+def get_json_config(key, firmware_version):
     """Get a value from the JSON configuration file.
 
     Returns None if key is not found or 
@@ -175,6 +175,8 @@ def get_json_config(key):
     """
 
     config_file_path = "/opt/dashcam/bin/config.json"
+    if geq(firmware_version, "5.7.88"):
+        config_file_path = "/opt/dashcam/bin/db-config.json"
     try:
         with open(config_file_path, "r") as f:
             config = json.load(f)
@@ -227,7 +229,7 @@ def main():
         lte_capture_check()
 
         if geq(firmware_version, "5.4.19"):
-            db_path = get_json_config("ODC_API_DB_PATH")
+            db_path = get_json_config("ODC_API_DB_PATH", firmware_version)
             plugin_name = "beekeeper-plugin"
             state = "enabled"
             enable_bk(db_path, plugin_name, state)


### PR DESCRIPTION
## Overview

- [x] Implementation (Implements a new feature, library or extends existing ones)

## What? - Description of changes

Adds a check in get_json_config against firmware version

## Why?

The configuration filename changed between versions 5.4.20 and 5.7.88

## Verification/Testing

Tested get_json_config on a 5.7.88 camera, and verified it got the proper config file path.

## How? (Optional)

--

## Impact/Communications (Optional)

--

## Additional Information (Optional)

--